### PR TITLE
changing order of split and calling in transformer

### DIFF
--- a/src/preprocessing.py
+++ b/src/preprocessing.py
@@ -58,6 +58,15 @@ def main(quebec_path, store_path):
     assert quebec_df.dtypes.host_response_rate == 'float64', "host_reponse_rate string to float did not convert properly"
     assert quebec_df.dtypes.host_is_superhost == 'int64', "host_is_superhost boolean to number did not convert properly"
 
+    #making an 80-20 train-test split
+    X = quebec_df.drop(columns = ['price'])
+    y = quebec_df[['price']]
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size = 0.2, random_state = 5)
+
+    #making sure split sizes are correct
+    assert X_train.shape[1] == 44, "X_train did not split properly"
+    assert y_train.shape[1] == 1, "y_train did not split properly"
+
     #assigning categorical and numeric features
     categorical_features = ['host_response_time', 'property_type', 'room_type', 'bed_type']
     numeric_features = ['host_response_rate', 'host_is_superhost', 'host_listings_count', 'host_has_profile_pic', 'host_identity_verified', 'latitude', 'longitude', 'is_location_exact', 'accommodates', 'bathrooms', 'bedrooms', 'beds', 'guests_included', 'extra_people', 'minimum_nights', 'maximum_nights', 'has_availability', 'availability_30', 'availability_60', 'availability_90', 'availability_365', 'number_of_reviews', 'number_of_reviews_ltm', 'review_scores_rating', 'review_scores_accuracy', 'review_scores_cleanliness', 'review_scores_checkin', 'review_scores_communication', 'review_scores_location', 'review_scores_value', 'requires_license', 'instant_bookable', 'is_business_travel_ready', 'require_guest_profile_picture', 'require_guest_phone_verification', 'calculated_host_listings_count', 'calculated_host_listings_count_entire_homes', 'calculated_host_listings_count_private_rooms', 'calculated_host_listings_count_shared_rooms', 'reviews_per_month']
@@ -68,16 +77,6 @@ def main(quebec_path, store_path):
         ('scale', StandardScaler(), numeric_features),
         ('ohe', OneHotEncoder(handle_unknown= 'ignore'), categorical_features)
     ])
-
-
-    #making an 80-20 train-test split
-    X = quebec_df.drop(columns = ['price'])
-    y = quebec_df[['price']]
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size = 0.2, random_state = 5)
-
-    #making sure split sizes are correct
-    assert X_train.shape[1] == 44, "X_train did not split properly"
-    assert y_train.shape[1] == 1, "y_train did not split properly"
 
     #transforming data
     X_train = pd.DataFrame(preprocessor.fit_transform(X_train), index=X_train.index, columns = (numeric_features + list(preprocessor.named_transformers_['ohe'].get_feature_names(categorical_features))))
@@ -98,4 +97,4 @@ def main(quebec_path, store_path):
     quebec_df.to_csv(store_path, index = True, header = True)
 
 if __name__ == "__main__":
-    main(opt["--quebec_path"], opt["--store_path"])
+    main(opt["--quebec_path"], opt["--store_path"]) 


### PR DESCRIPTION
TA feedback indicated that it looked like we were splitting the test/train sets after fit-transforming the data. In reality, the transformers were called in before the split but were not applied until after the data was split. To mitigate this, I moved the code chunk where the fit-transformers were called in to after the split.